### PR TITLE
Change URL formatting for IVI

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -3,3 +3,4 @@
 ^data-raw$
 ^README\.Rmd$
 ^\.github$
+^LICENSE\.md$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,15 +1,18 @@
 Package: readjsa
 Title: Read data from Jobs & Skills Australia in a tidy tibble
-Version: 0.0.0.9102
+Version: 0.0.0.920
 Authors@R: 
+  c(
     person("Matt", "Cowgill", , "mattcowgill@gmail.com", role = c("aut", "cre"),
-           comment = c(ORCID = "0000-0003-0422-3300"))
+           comment = c(ORCID = "0000-0003-0422-3300")),
+    person("Angus", "Hughes", role = "ctb")
+           )
 Description: Download, import, and tidy Jobs & Skills Australia data.
 License: MIT + file LICENSE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE, roclets = c("collate", "namespace", "rd",
     "roxyglobals::global_roclet"))
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.1
 Suggests: 
     roxyglobals,
     testthat (>= 3.0.0),

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,2 @@
-MIT License
-
-Copyright (c) 2024 Matt Cowgill
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+YEAR: 2024
+COPYRIGHT HOLDER: readjsa authors

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+# MIT License
+
+Copyright (c) 2024 readjsa authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# readjsa 0.0.0.920
+* A fix thanks to @awhug for some JSA IVI URL changes 
+
 # readjsa 0.0.0.9102
 
 * Another fix due to JSA changes

--- a/R/dl.R
+++ b/R/dl.R
@@ -10,6 +10,8 @@ dl_file <- function(urls,
 
   check_jsa_connection()
 
+  urls <- utils::URLencode(urls) # Ensure url strings have valid encoding
+
   safely_dl <- purrr::safely(\(...) {
     utils::download.file(...,
       mode = "wb",
@@ -37,7 +39,7 @@ dl_file <- function(urls,
     return(file)
   } else {
     stop(
-      "Could not download REOS file from urls: ",
+      "Could not download file from urls: ",
       paste(urls, collapse = ", or "),
       "."
     )

--- a/R/ivi.R
+++ b/R/ivi.R
@@ -121,7 +121,7 @@ possible_ivi_urls <- function(table = c("skill",
   prev_month_short <- format(prev_month, "%Y-%m")
 
   month_to_url_text <- function(date) {
-    tolower(format(date, "%B_%Y"))
+    format(date, "%B %Y")
   }
 
   prev_month_long <- month_to_url_text(prev_month)
@@ -130,10 +130,10 @@ possible_ivi_urls <- function(table = c("skill",
   base_url <- "https://www.jobsandskills.gov.au/sites/default/files/"
 
   table_specific_url_fragment <- switch(table,
-    "skill" = "internet_vacancies_anzsco_skill_level_states_and_territories_-_",
-    "4dig" = "internet_vacancies_anzsco4_occupations_states_and_territories_-_",
-    "2dig_states" = "internet_vacancies_anzsco2_occupations_states_and_territories_-_",
-    "2dig_regions" = "internet_vacancies_anzsco2_occupations_ivi_regions_-_"
+    "skill" = "Internet Vacancies, ANZSCO Skill Level, States and Territories - ",
+    "4dig" = "Internet Vacancies, ANZSCO4 Occupations, States and Territories - ",
+    "2dig_regions" = "Internet Vacancies, ANZSCO2 Occupations, IVI Regions - ",
+    "2dig_states" = "Internet Vacancies, ANZSCO2 Occupations, States and Territories - "
   )
 
   urls <- paste0(


### PR DESCRIPTION
Looks like JSA has changed the file name formatting of the IVI data to an even less machine-readable format. The `read_ivi` functionality as implemented in the package currently is broken.

This fixes the links and enforces URL-encoding as part of the `dl_file` to handle whitespace characters. The tests appear to be running ok for me now.